### PR TITLE
🌈 style(mobile): update social connection button styles and layout

### DIFF
--- a/apps/mobile-queue/components/social-connections.tsx
+++ b/apps/mobile-queue/components/social-connections.tsx
@@ -37,7 +37,7 @@ const SOCIAL_CONNECTION_STRATEGIES: {
     label: 'Continue with Apple',
     source: { uri: 'https://img.clerk.com/static/apple.png?width=160' },
     useTint: true,
-    backgroundColor: 'bg-black',
+    backgroundColor: 'bg-[#007AFF]',
     textColor: 'text-white',
   },
   {
@@ -92,19 +92,21 @@ export function SocialConnections() {
           <Button
             key={strategy.type}
             className={cn(
-              'h-12 w-full flex-row items-center justify-center gap-3 rounded-full',
+              'h-12 w-full flex-row items-center justify-start gap-3 rounded-full pl-1',
               strategy.backgroundColor,
               'border-0'
             )}
             onPress={onSocialLoginPress(strategy.type)}>
-            <Image
-              className={cn('size-5', strategy.useTint && Platform.select({ web: 'dark:invert' }))}
-              tintColor={Platform.select({
-                native: strategy.useTint ? 'white' : undefined,
-              })}
-              source={strategy.source}
-            />
-            <Text className={cn('text-base font-medium', strategy.textColor)}>
+            <View className="h-10 w-10 items-center justify-center rounded-full bg-white">
+              <Image
+                className={cn('size-5', strategy.useTint && Platform.select({ web: 'dark:invert' }))}
+                tintColor={Platform.select({
+                  native: strategy.useTint ? 'black' : undefined,
+                })}
+                source={strategy.source}
+              />
+            </View>
+            <Text className={cn('text-base font-medium flex-1 text-center', strategy.textColor)}>
               {strategy.label}
             </Text>
           </Button>

--- a/apps/mobile-queue/components/social-connections.tsx
+++ b/apps/mobile-queue/components/social-connections.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
 import { cn } from '@/lib/utils';
 import { useSSO, type StartSSOFlowParams } from '@clerk/clerk-expo';
 import * as AuthSession from 'expo-auth-session';
@@ -17,23 +18,35 @@ type SocialConnectionStrategy = Extract<
 
 const SOCIAL_CONNECTION_STRATEGIES: {
   type: SocialConnectionStrategy;
+  label: string;
   source: ImageSourcePropType;
   useTint?: boolean;
+  backgroundColor: string;
+  textColor: string;
 }[] = [
   {
-    type: 'oauth_apple',
-    source: { uri: 'https://img.clerk.com/static/apple.png?width=160' },
-    useTint: true,
-  },
-  {
     type: 'oauth_google',
+    label: 'Continue with Google',
     source: { uri: 'https://img.clerk.com/static/google.png?width=160' },
     useTint: false,
+    backgroundColor: 'bg-[#4285F4]',
+    textColor: 'text-white',
+  },
+  {
+    type: 'oauth_apple',
+    label: 'Continue with Apple',
+    source: { uri: 'https://img.clerk.com/static/apple.png?width=160' },
+    useTint: true,
+    backgroundColor: 'bg-black',
+    textColor: 'text-white',
   },
   {
     type: 'oauth_github',
+    label: 'Continue with GitHub',
     source: { uri: 'https://img.clerk.com/static/github.png?width=160' },
     useTint: true,
+    backgroundColor: 'bg-black',
+    textColor: 'text-white',
   },
 ];
 
@@ -73,22 +86,27 @@ export function SocialConnections() {
   }
 
   return (
-    <View className="gap-2 sm:flex-row sm:gap-3">
+    <View className="gap-3">
       {SOCIAL_CONNECTION_STRATEGIES.map((strategy) => {
         return (
           <Button
             key={strategy.type}
-            variant="outline"
-            size="sm"
-            className="sm:flex-1"
+            className={cn(
+              'h-12 w-full flex-row items-center justify-center gap-3 rounded-full',
+              strategy.backgroundColor,
+              'border-0'
+            )}
             onPress={onSocialLoginPress(strategy.type)}>
             <Image
-              className={cn('size-4', strategy.useTint && Platform.select({ web: 'dark:invert' }))}
+              className={cn('size-5', strategy.useTint && Platform.select({ web: 'dark:invert' }))}
               tintColor={Platform.select({
-                native: strategy.useTint ? (colorScheme === 'dark' ? 'white' : 'black') : undefined,
+                native: strategy.useTint ? 'white' : undefined,
               })}
               source={strategy.source}
             />
+            <Text className={cn('text-base font-medium', strategy.textColor)}>
+              {strategy.label}
+            </Text>
           </Button>
         );
       })}

--- a/apps/mobile-queue/components/social-connections.tsx
+++ b/apps/mobile-queue/components/social-connections.tsx
@@ -33,20 +33,20 @@ const SOCIAL_CONNECTION_STRATEGIES: {
     textColor: 'text-gray-700',
   },
   {
-    type: 'oauth_apple',
-    label: 'Continue with Apple',
-    source: { uri: 'https://img.clerk.com/static/apple.png?width=160' },
-    useTint: true,
-    backgroundColor: 'bg-gray-50 border border-gray-200',
-    textColor: 'text-gray-700',
-  },
-  {
     type: 'oauth_github',
     label: 'Continue with GitHub',
     source: { uri: 'https://img.clerk.com/static/github.png?width=160' },
     useTint: true,
     backgroundColor: 'bg-gray-100 border border-gray-200',
     textColor: 'text-gray-700',
+  },
+  {
+    type: 'oauth_apple',
+    label: 'Sign in with Apple',
+    source: { uri: 'https://img.clerk.com/static/apple.png?width=160' },
+    useTint: true,
+    backgroundColor: 'bg-black',
+    textColor: 'text-white',
   },
 ];
 
@@ -96,14 +96,20 @@ export function SocialConnections() {
               strategy.backgroundColor
             )}
             onPress={onSocialLoginPress(strategy.type)}>
-            <View className="h-10 w-10 items-center justify-center rounded-full bg-white">
+            <View
+              className={cn(
+                'h-10 w-10 items-center justify-center rounded-full',
+                strategy.type === 'oauth_apple' ? 'bg-transparent' : 'bg-white'
+              )}>
               <Image
-                className={cn(
-                  'size-5',
-                  strategy.useTint && Platform.select({ web: 'dark:invert' })
-                )}
+                className="size-5"
                 tintColor={Platform.select({
-                  native: strategy.useTint ? 'black' : undefined,
+                  // Keep Apple glyph white on black; others stay black on white puck.
+                  native: strategy.useTint
+                    ? strategy.type === 'oauth_apple'
+                      ? 'white'
+                      : 'black'
+                    : undefined,
                 })}
                 source={strategy.source}
               />

--- a/apps/mobile-queue/components/social-connections.tsx
+++ b/apps/mobile-queue/components/social-connections.tsx
@@ -29,24 +29,24 @@ const SOCIAL_CONNECTION_STRATEGIES: {
     label: 'Continue with Google',
     source: { uri: 'https://img.clerk.com/static/google.png?width=160' },
     useTint: false,
-    backgroundColor: 'bg-[#4285F4]',
-    textColor: 'text-white',
+    backgroundColor: 'bg-gray-100 border border-gray-200',
+    textColor: 'text-gray-700',
   },
   {
     type: 'oauth_apple',
     label: 'Continue with Apple',
     source: { uri: 'https://img.clerk.com/static/apple.png?width=160' },
     useTint: true,
-    backgroundColor: 'bg-[#007AFF]',
-    textColor: 'text-white',
+    backgroundColor: 'bg-gray-50 border border-gray-200',
+    textColor: 'text-gray-700',
   },
   {
     type: 'oauth_github',
     label: 'Continue with GitHub',
     source: { uri: 'https://img.clerk.com/static/github.png?width=160' },
     useTint: true,
-    backgroundColor: 'bg-black',
-    textColor: 'text-white',
+    backgroundColor: 'bg-gray-100 border border-gray-200',
+    textColor: 'text-gray-700',
   },
 ];
 
@@ -93,20 +93,22 @@ export function SocialConnections() {
             key={strategy.type}
             className={cn(
               'h-12 w-full flex-row items-center justify-start gap-3 rounded-full pl-1',
-              strategy.backgroundColor,
-              'border-0'
+              strategy.backgroundColor
             )}
             onPress={onSocialLoginPress(strategy.type)}>
             <View className="h-10 w-10 items-center justify-center rounded-full bg-white">
               <Image
-                className={cn('size-5', strategy.useTint && Platform.select({ web: 'dark:invert' }))}
+                className={cn(
+                  'size-5',
+                  strategy.useTint && Platform.select({ web: 'dark:invert' })
+                )}
                 tintColor={Platform.select({
                   native: strategy.useTint ? 'black' : undefined,
                 })}
                 source={strategy.source}
               />
             </View>
-            <Text className={cn('text-base font-medium flex-1 text-center', strategy.textColor)}>
+            <Text className={cn('flex-1 text-center text-base font-medium', strategy.textColor)}>
               {strategy.label}
             </Text>
           </Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Social sign-in buttons now show clear labels for Google, Apple, and GitHub alongside their icons for improved clarity and accessibility.
  - Background pre-warming for web sign-in to speed up SSO flow.

- Style
  - Vertical stacked layout with improved spacing.
  - Brand-aligned button colors and contrast per provider.
  - Circular white icon backdrop and refined icon tinting.
  - Larger, borderless buttons for easier tapping.

- Notes
  - Sign-in behavior and flows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->