### PR TITLE
✨ feat(mobile/splash): prevent splash screen from auto-hiding on native platforms.

### DIFF
--- a/apps/mobile-queue/app/(tabs)/_layout.tsx
+++ b/apps/mobile-queue/app/(tabs)/_layout.tsx
@@ -4,6 +4,7 @@ import { HomeIcon, SparklesIcon, CalendarDaysIcon, SettingsIcon } from 'lucide-r
 import { useColorScheme } from 'nativewind';
 import * as React from 'react';
 import * as SplashScreen from 'expo-splash-screen';
+import { Platform } from 'react-native';
 
 export default function TabLayout() {
   const { colorScheme } = useColorScheme();
@@ -11,7 +12,11 @@ export default function TabLayout() {
 
   // Ensure splash screen is hidden once the tabs layout mounts.
   React.useEffect(() => {
-    SplashScreen.hideAsync().catch(() => {});
+    if (Platform.OS !== 'web') {
+      SplashScreen.hideAsync().catch((error) => {
+        console.warn('Error hiding splash screen in tabs layout:', error);
+      });
+    }
   }, []);
 
   return (

--- a/apps/mobile-queue/app/(tabs)/_layout.tsx
+++ b/apps/mobile-queue/app/(tabs)/_layout.tsx
@@ -2,10 +2,17 @@ import { Tabs } from 'expo-router';
 import { Icon } from '@/components/ui/icon';
 import { HomeIcon, SparklesIcon, CalendarDaysIcon, SettingsIcon } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
+import * as React from 'react';
+import * as SplashScreen from 'expo-splash-screen';
 
 export default function TabLayout() {
   const { colorScheme } = useColorScheme();
   const isDark = colorScheme === 'dark';
+
+  // Ensure splash screen is hidden once the tabs layout mounts.
+  React.useEffect(() => {
+    SplashScreen.hideAsync().catch(() => {});
+  }, []);
 
   return (
     <Tabs

--- a/apps/mobile-queue/app/_layout.tsx
+++ b/apps/mobile-queue/app/_layout.tsx
@@ -14,8 +14,16 @@ import { StatusBar } from 'expo-status-bar';
 import { useColorScheme } from 'nativewind';
 import * as React from 'react';
 import Constants from 'expo-constants';
-import { View, Text } from 'react-native';
+import { View, Text, Platform } from 'react-native';
 import * as Sentry from '@sentry/react-native';
+
+// Prevent the splash screen from auto-hiding before our app is ready
+// Only call this on native platforms (iOS/Android)
+if (Platform.OS !== 'web') {
+  SplashScreen.preventAutoHideAsync().catch((error) => {
+    console.warn('Error preventing splash screen auto-hide:', error);
+  });
+}
 
 Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
@@ -84,14 +92,14 @@ export default Sentry.wrap(function RootLayout() {
   );
 });
 
-SplashScreen.preventAutoHideAsync();
-
 function Routes() {
   const { isSignedIn, isLoaded } = useAuth();
 
   React.useEffect(() => {
-    if (isLoaded) {
-      SplashScreen.hideAsync();
+    if (isLoaded && Platform.OS !== 'web') {
+      SplashScreen.hideAsync().catch((error) => {
+        console.warn('Error hiding splash screen:', error);
+      });
     }
   }, [isLoaded]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Splash screen now reliably hides after the tabs layout mounts, reducing stuck screens and startup flicker.
  * Splash-screen auto-hide/prevent logic is applied only on native platforms, avoiding web-side issues.
  * Disables splash-screen controls in browsers to prevent unexpected behavior.
  * Adds error handling around splash operations to avoid crashes and surface warnings.
  * No changes to navigation or authentication; only the launch experience is refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->